### PR TITLE
Support launch files

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2autodoc</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>
     The ROS2 autodoc project provides a CLI command to automatically generate ROS-Wiki-style documentation template nodes in markdown syntax.
   </description>

--- a/ros2autodoc/api/doc_writer.py
+++ b/ros2autodoc/api/doc_writer.py
@@ -44,6 +44,7 @@ class DocWriter:
                 for name, entry in self.interfaces["services"].items():
                     self._write_entry(f, name, entry)
             if self.interfaces["actions"]:
+                f.write("### Actions\n\n")
                 for name, entry in self.interfaces["actions"].items():
                     self._write_entry(f, name, entry)
 

--- a/ros2autodoc/api/node_runner.py
+++ b/ros2autodoc/api/node_runner.py
@@ -11,26 +11,31 @@ class NodeRunner:
     def __init__(self):
         self.process = None
 
-    def start(self, package_name, executable_name):
-        try:
-            path = get_executable_path(
-                package_name=package_name, executable_name=executable_name
-            )
-        except PackageNotFound:
-            raise RuntimeError(f"Package '{package_name}' not found")
-        except MultipleExecutables as e:
-            msg = "Multiple executables found:"
-            for p in e.paths:
-                msg += f"\n- {p}"
-            raise RuntimeError(msg)
-        if path is None:
-            return "No executable found"
+    def start(self, package_name, executable_name=None, launch_file=None):
+        """Start a node either using ros2 run or ros2 launch."""
+        if executable_name:
+            try:
+                path = get_executable_path(
+                    package_name=package_name, executable_name=executable_name
+                )
+            except PackageNotFound:
+                raise RuntimeError(f"Package '{package_name}' not found")
+            except MultipleExecutables as e:
+                msg = "Multiple executables found:"
+                for p in e.paths:
+                    msg += f"\n- {p}"
+                raise RuntimeError(msg)
+            if path is None:
+                return "No executable found"
 
-        cmd = [path]
+            cmd = [path]
 
-        # on Windows Python scripts are invocable through the interpreter
-        if os.name == "nt" and path.endswith(".py"):
-            cmd.insert(0, sys.executable)
+            # on Windows Python scripts are invocable through the interpreter
+            if os.name == "nt" and path.endswith(".py"):
+                cmd.insert(0, sys.executable)
+        
+        elif launch_file:
+            cmd = ["ros2", "launch", package_name, launch_file]
 
         self.process = subprocess.Popen(
             cmd, shell=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL

--- a/ros2autodoc/api/node_runner.py
+++ b/ros2autodoc/api/node_runner.py
@@ -33,7 +33,7 @@ class NodeRunner:
             # on Windows Python scripts are invocable through the interpreter
             if os.name == "nt" and path.endswith(".py"):
                 cmd.insert(0, sys.executable)
-        
+
         elif launch_file:
             cmd = ["ros2", "launch", package_name, launch_file]
 

--- a/ros2autodoc/verb/check.py
+++ b/ros2autodoc/verb/check.py
@@ -58,11 +58,7 @@ class CheckVerb(VerbExtension):
         if args.executables:
             # Check if the number of nodes matches the executables
             if len(args.nodes) != len(args.executables):
-                return_str = (
-                    f"Number of nodes ({len(args.nodes)}) "
-                    + f"does not match the number of executables ({len(args.executables)})."
-                )
-                return return_str
+                return "Number of nodes doesn't match the number of executables."
 
             # Check if the package contains all the executables
             paths = get_executable_paths(package_name=args.package_name)
@@ -88,7 +84,7 @@ class CheckVerb(VerbExtension):
                         sys.exit(1)
                     print(f"Node '{node_name}' interfaces are correctly listed.")
                 runner.stop()
-            
+
             elif args.executables:
                 for node_name, executable_name in zip(args.nodes, args.executables):
                     runner.start(args.package_name, executable_name)

--- a/ros2autodoc/verb/check.py
+++ b/ros2autodoc/verb/check.py
@@ -19,6 +19,12 @@ class CheckVerb(VerbExtension):
             help="name of the package containing the nodes to be documented.",
         )
         parser.add_argument(
+            "--launch-file",
+            default=None,
+            metavar="launch_file",
+            help="name of the launch file to start the nodes.",
+        )
+        parser.add_argument(
             "--nodes",
             metavar="node",
             nargs="*",
@@ -46,36 +52,50 @@ class CheckVerb(VerbExtension):
             return f"Package '{args.package_name}' could not be found."
 
         # Check if all inputs were provided
-        if not args.nodes or not args.executables:
-            return "At least one node and one executable are required."
+        if not args.nodes and (not args.executables or not args.launch_file):
+            return "At least one node and one executable or launch file are required."
 
-        # Check if the number of nodes matches the executables
-        if len(args.nodes) != len(args.executables):
-            return_str = (
-                f"Number of nodes ({len(args.nodes)}) "
-                + f"does not match the number of executables ({len(args.executables)})."
-            )
-            return return_str
+        if args.executables:
+            # Check if the number of nodes matches the executables
+            if len(args.nodes) != len(args.executables):
+                return_str = (
+                    f"Number of nodes ({len(args.nodes)}) "
+                    + f"does not match the number of executables ({len(args.executables)})."
+                )
+                return return_str
 
-        # Check if the package contains all the executables
-        paths = get_executable_paths(package_name=args.package_name)
-        executables = [basename(path) for path in paths]
-        missing_executables = [
-            exe for exe in args.executables if exe not in executables
-        ]
-        if missing_executables:
-            return f"Missing executables: {', '.join(missing_executables)}"
+            # Check if the package contains all the executables
+            paths = get_executable_paths(package_name=args.package_name)
+            executables = [basename(path) for path in paths]
+            missing_executables = [
+                exe for exe in args.executables if exe not in executables
+            ]
+            if missing_executables:
+                return f"Missing executables: {', '.join(missing_executables)}"
 
         # Create runner to start the nodes
         runner = NodeRunner()
 
         with NodeStrategy(args) as node:
-            for node_name, executable_name in zip(args.nodes, args.executables):
-                runner.start(args.package_name, executable_name)
-                if not check_for_node(node, f"/{node_name}"):
-                    print(f"Node '{node_name}' is not running and will be ignored.")
-                    continue
-                if not check_node_documentation(node, node_name, args.input_file):
-                    sys.exit(1)
-                print(f"Node '{node_name}' interfaces are correctly listed.")
+            if args.launch_file:
+                runner.start(args.package_name, launch_file=args.launch_file)
+
+                for node_name in args.nodes:
+                    if not check_for_node(node, f"/{node_name}"):
+                        print(f"Node '{node_name}' is not running and will be ignored.")
+                        continue
+                    if not check_node_documentation(node, node_name, args.input_file):
+                        sys.exit(1)
+                    print(f"Node '{node_name}' interfaces are correctly listed.")
                 runner.stop()
+            
+            elif args.executables:
+                for node_name, executable_name in zip(args.nodes, args.executables):
+                    runner.start(args.package_name, executable_name)
+                    if not check_for_node(node, f"/{node_name}"):
+                        print(f"Node '{node_name}' is not running and will be ignored.")
+                        continue
+                    if not check_node_documentation(node, node_name, args.input_file):
+                        sys.exit(1)
+                    print(f"Node '{node_name}' interfaces are correctly listed.")
+                    runner.stop()

--- a/ros2autodoc/verb/generate.py
+++ b/ros2autodoc/verb/generate.py
@@ -62,11 +62,7 @@ class GenerateVerb(VerbExtension):
         if args.executables:
             # Check if the number of nodes matches the executables
             if len(args.nodes) != len(args.executables):
-                return_str = (
-                    f"Number of nodes ({len(args.nodes)}) "
-                    + f"does not match the number of executables ({len(args.executables)})."
-                )
-                return return_str
+                return "Number of nodes doesn't match the number of executables."
 
             # Check if the package contains all the executables
             paths = get_executable_paths(package_name=args.package_name)
@@ -103,9 +99,9 @@ class GenerateVerb(VerbExtension):
                             node_name,
                             f"{args.output_dir}/README.md",
                         )
-                       
+
                 runner.stop()
-            
+
             elif args.executables:
                 for node_name, executable_name in zip(args.nodes, args.executables):
 

--- a/ros2autodoc/verb/generate.py
+++ b/ros2autodoc/verb/generate.py
@@ -56,7 +56,7 @@ class GenerateVerb(VerbExtension):
             return f"Package '{args.package_name}' could not be found."
 
         # Check if all inputs were provided
-        if not args.nodes or not args.executables or not args.launch_file:
+        if not args.nodes and (not args.executables or not args.launch_file):
             return "At least one node and one executable or launch file are required."
 
         if args.executables:

--- a/ros2autodoc/verb/generate.py
+++ b/ros2autodoc/verb/generate.py
@@ -30,6 +30,12 @@ class GenerateVerb(VerbExtension):
             help="name of the executables for the nodes to be documented.",
         )
         parser.add_argument(
+            "--launch-file",
+            default=None,
+            metavar="launch_file",
+            help="name of the launch file to start the nodes.",
+        )
+        parser.add_argument(
             "--output-dir",
             default=abspath(curdir),
             metavar="",
@@ -50,25 +56,26 @@ class GenerateVerb(VerbExtension):
             return f"Package '{args.package_name}' could not be found."
 
         # Check if all inputs were provided
-        if not args.nodes or not args.executables:
-            return "At least one node and one executable are required."
+        if not args.nodes or not args.executables or not args.launch_file:
+            return "At least one node and one executable or launch file are required."
 
-        # Check if the number of nodes matches the executables
-        if len(args.nodes) != len(args.executables):
-            return_str = (
-                f"Number of nodes ({len(args.nodes)}) "
-                + f"does not match the number of executables ({len(args.executables)})."
-            )
-            return return_str
+        if args.executables:
+            # Check if the number of nodes matches the executables
+            if len(args.nodes) != len(args.executables):
+                return_str = (
+                    f"Number of nodes ({len(args.nodes)}) "
+                    + f"does not match the number of executables ({len(args.executables)})."
+                )
+                return return_str
 
-        # Check if the package contains all the executables
-        paths = get_executable_paths(package_name=args.package_name)
-        executables = [basename(path) for path in paths]
-        missing_executables = [
-            exe for exe in args.executables if exe not in executables
-        ]
-        if missing_executables:
-            return f"Missing executables: {', '.join(missing_executables)}"
+            # Check if the package contains all the executables
+            paths = get_executable_paths(package_name=args.package_name)
+            executables = [basename(path) for path in paths]
+            missing_executables = [
+                exe for exe in args.executables if exe not in executables
+            ]
+            if missing_executables:
+                return f"Missing executables: {', '.join(missing_executables)}"
 
         # Ensure no trailing slash
         args.output_dir = args.output_dir.rstrip("/")
@@ -77,22 +84,45 @@ class GenerateVerb(VerbExtension):
         runner = NodeRunner()
 
         with NodeStrategy(args) as node:
-            for node_name, executable_name in zip(args.nodes, args.executables):
+            if args.launch_file:
+                runner.start(args.package_name, launch_file=args.launch_file)
 
-                runner.start(args.package_name, executable_name)
+                for node_name in args.nodes:
 
-                if not check_for_node(node, f"/{node_name}"):
-                    print(f"Node '{node_name}' is not running and will be ignored.")
-                    continue
-                if args.seperate_files:
-                    document_node(
-                        node, None, node_name, f"{args.output_dir}/{node_name}.md"
-                    )
-                else:
-                    document_node(
-                        node,
-                        args.package_name,
-                        node_name,
-                        f"{args.output_dir}/README.md",
-                    )
+                    if not check_for_node(node, f"/{node_name}"):
+                        print(f"Node '{node_name}' is not running and will be ignored.")
+                        continue
+                    if args.seperate_files:
+                        document_node(
+                            node, None, node_name, f"{args.output_dir}/{node_name}.md"
+                        )
+                    else:
+                        document_node(
+                            node,
+                            args.package_name,
+                            node_name,
+                            f"{args.output_dir}/README.md",
+                        )
+                       
                 runner.stop()
+            
+            elif args.executables:
+                for node_name, executable_name in zip(args.nodes, args.executables):
+
+                    runner.start(args.package_name, executable_name=executable_name)
+
+                    if not check_for_node(node, f"/{node_name}"):
+                        print(f"Node '{node_name}' is not running and will be ignored.")
+                        continue
+                    if args.seperate_files:
+                        document_node(
+                            node, None, node_name, f"{args.output_dir}/{node_name}.md"
+                        )
+                    else:
+                        document_node(
+                            node,
+                            args.package_name,
+                            node_name,
+                            f"{args.output_dir}/README.md",
+                        )
+                    runner.stop()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ PACKAGE_NAME = "ros2autodoc"
 
 setup(
     name=PACKAGE_NAME,
-    version="2.0.0",
+    version="2.1.0",
     packages=find_packages(exclude=["test"]),
     data_files=[
         ("share/" + PACKAGE_NAME, ["package.xml"]),


### PR DESCRIPTION
This PR implements support for launch files as a mechanism to start nodes. This allows composable nodes to be started and therefore closes #64. This also fixes a bug in the doc_writer.py where Actions section head was not written to the file.