### PR TITLE
Increase wait time for check_for_node

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2autodoc</name>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <description>
     The ROS2 autodoc project provides a CLI command to automatically generate ROS-Wiki-style documentation template nodes in markdown syntax.
   </description>

--- a/ros2autodoc/api/__init__.py
+++ b/ros2autodoc/api/__init__.py
@@ -20,7 +20,7 @@ def check_for_package(package_name):
     return True
 
 
-def check_for_node(node, node_name, timeout=1.0):
+def check_for_node(node, node_name, timeout=10.0):
     """Check if the given node is available and running."""
     start_time = time.time()
     end_time = start_time + timeout

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ PACKAGE_NAME = "ros2autodoc"
 
 setup(
     name=PACKAGE_NAME,
-    version="2.1.0",
+    version="2.1.1",
     packages=find_packages(exclude=["test"]),
     data_files=[
         ("share/" + PACKAGE_NAME, ["package.xml"]),


### PR DESCRIPTION
Some systems require longer to start the nodes resulting in skipping the node as the check_for_node times out. This PR increses the timeout to 10 seconds